### PR TITLE
Adds support for saved settings and BETA testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 out/production/
 log.log
 log/log.log.lck
+Settings.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 out/production/
 log.log
 log/log.log.lck
-Settings.txt
-out/artifacts/
+*.txt
+out/artifacts/*
 !out/artifacts/TOA_DataSync_jar

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ out/production/
 log.log
 log/log.log.lck
 Settings.txt
-out/artifacts/TOA_DataSync_AGardner/
+out/artifacts/
+!out/artifacts/TOA_DataSync_jar

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ out/production/
 log.log
 log/log.log.lck
 Settings.txt
+out/artifacts/TOA_DataSync_AGardner/

--- a/res/DataSync.fxml
+++ b/res/DataSync.fxml
@@ -14,133 +14,133 @@
         <tabs>
             <Tab fx:id="tabSetup" closable="false" text="Setup">
                 <content>
-              <AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="426.0" prefWidth="720.0">
-                     <children>
-                        <Separator layoutX="357.0" layoutY="13.0" orientation="VERTICAL" prefHeight="400.0" />
-                        <GridPane layoutY="13.0" prefHeight="399.0" prefWidth="350.0">
-                          <columnConstraints>
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                          </columnConstraints>
-                          <rowConstraints>
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                          </rowConstraints>
-                           <children>
-                              <Label text="Connection Test" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER" GridPane.valignment="CENTER">
-                                 <font>
-                                    <Font size="28.0" />
-                                 </font>
-                              </Label>
-                              <Label text="1. Input your event API key given to you by TOA." GridPane.columnSpan="2147483647" GridPane.rowIndex="1">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font name="System Bold" size="12.0" />
-                                 </font>
-                              </Label>
-                              <TextField fx:id="txtSetupKey" alignment="CENTER" promptText="Event API Key" GridPane.columnIndex="1" GridPane.columnSpan="3" GridPane.rowIndex="2">
-                                 <GridPane.margin>
-                                    <Insets left="5.0" right="5.0" />
-                                 </GridPane.margin>
-                              </TextField>
-                              <Label text="Event API Key" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
-                              <Label text="2. Input your event id as listed on TOA (E.G. 1718-FIM-PET)." GridPane.columnSpan="2147483647" GridPane.rowIndex="3">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font name="System Bold" size="12.0" />
-                                 </font>
-                              </Label>
-                              <Label text="Event ID" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
-                              <TextField fx:id="txtSetupID" alignment="CENTER" promptText="Event ID" GridPane.columnIndex="1" GridPane.columnSpan="3" GridPane.rowIndex="4">
-                                 <GridPane.margin>
-                                    <Insets left="5.0" right="5.0" />
-                                 </GridPane.margin>
-                              </TextField>
-                              <Label text="3. Test your connection by pressing the button below." GridPane.columnSpan="2147483647" GridPane.rowIndex="5">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font name="System Bold" size="12.0" />
-                                 </font>
-                              </Label>
-                              <Button fx:id="btnSetupTest" mnemonicParsing="false" onAction="#testConnection" text="Test Connection" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
-                              <Label fx:id="labelSetupTest" alignment="CENTER" prefHeight="35.0" prefWidth="150.0" text="Not Connected" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
-                              <Hyperlink onAction="#openDocs" text="(Documentation)" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="RIGHT" GridPane.rowIndex="8">
-                                 <GridPane.margin>
-                                    <Insets right="25.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font size="14.0" />
-                                 </font>
-                              </Hyperlink>
-                              <Label text="Copyright 2017 TheOrangeAlliance.org" GridPane.columnSpan="2147483647" GridPane.rowIndex="8">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font size="11.0" />
-                                 </font>
-                              </Label>
-                           </children>
-                        </GridPane>
-                        <GridPane layoutX="360.0" layoutY="13.0" prefHeight="399.0" prefWidth="350.0">
-                           <columnConstraints>
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                           </columnConstraints>
-                           <rowConstraints>
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                           </rowConstraints>
-                           <children>
-                              <Label text="Scoring System" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER">
-                                 <font>
-                                    <Font size="28.0" />
-                                 </font>
-                              </Label>
-                              <Label text="4. Start the FTC Scoring System and modify your event information. Once complete, choose the root folder of the scoring software." wrapText="true" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" GridPane.rowSpan="2">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" />
-                                 </GridPane.margin>
-                                 <font>
-                                    <Font name="System Bold" size="12.0" />
-                                 </font>
-                              </Label>
-                              <TextField fx:id="txtSetupDir" promptText="C:\Users\KyleFlynn\Scoring\FTC_Scoring" GridPane.columnSpan="3" GridPane.rowIndex="4">
-                                 <GridPane.margin>
-                                    <Insets left="10.0" right="10.0" />
-                                 </GridPane.margin>
-                              </TextField>
-                              <Button fx:id="btnSetupSelect" mnemonicParsing="false" onAction="#openScoringDialog" text="Open Folder" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
-                              <Label fx:id="labelSetupDir" alignment="CENTER" prefHeight="35.0" prefWidth="150.0" text="Invalid Directory" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
-                              <Button fx:id="btnSetupTestDir" mnemonicParsing="false" onAction="#testDirectory" text="Test Directory" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
-                           </children>
-                        </GridPane>
-                     </children></AnchorPane>
-            </content>
+                  <AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="426.0" prefWidth="720.0">
+                         <children>
+                            <Separator layoutX="357.0" layoutY="13.0" orientation="VERTICAL" prefHeight="400.0" />
+                            <GridPane layoutY="13.0" prefHeight="399.0" prefWidth="350.0">
+                              <columnConstraints>
+                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              </columnConstraints>
+                              <rowConstraints>
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              </rowConstraints>
+                               <children>
+                                  <Label text="Connection Test" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER" GridPane.valignment="CENTER">
+                                     <font>
+                                        <Font size="28.0" />
+                                     </font>
+                                  </Label>
+                                  <Label text="1. Input your event API key given to you by TOA." GridPane.columnSpan="2147483647" GridPane.rowIndex="1">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font name="System Bold" size="12.0" />
+                                     </font>
+                                  </Label>
+                                  <TextField fx:id="txtSetupKey" alignment="CENTER" promptText="Event API Key" GridPane.columnIndex="1" GridPane.columnSpan="3" GridPane.rowIndex="2">
+                                     <GridPane.margin>
+                                        <Insets left="5.0" right="5.0" />
+                                     </GridPane.margin>
+                                  </TextField>
+                                  <Label text="Event API Key" GridPane.halignment="RIGHT" GridPane.rowIndex="2" />
+                                  <Label text="2. Input your event id as listed on TOA (E.G. 1718-FIM-PET)." GridPane.columnSpan="2147483647" GridPane.rowIndex="3">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font name="System Bold" size="12.0" />
+                                     </font>
+                                  </Label>
+                                  <Label text="Event ID" GridPane.halignment="RIGHT" GridPane.rowIndex="4" />
+                                  <TextField fx:id="txtSetupID" alignment="CENTER" promptText="Event ID" GridPane.columnIndex="1" GridPane.columnSpan="3" GridPane.rowIndex="4">
+                                     <GridPane.margin>
+                                        <Insets left="5.0" right="5.0" />
+                                     </GridPane.margin>
+                                  </TextField>
+                                  <Label text="3. Test your connection by pressing the button below." GridPane.columnSpan="2147483647" GridPane.rowIndex="5">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font name="System Bold" size="12.0" />
+                                     </font>
+                                  </Label>
+                                  <Button fx:id="btnSetupTest" mnemonicParsing="false" onAction="#testConnection" text="Test Connection" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
+                                  <Label fx:id="labelSetupTest" alignment="CENTER" prefHeight="35.0" prefWidth="150.0" text="Not Connected" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
+                                  <Hyperlink onAction="#openDocs" text="(Documentation)" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="RIGHT" GridPane.rowIndex="8">
+                                     <GridPane.margin>
+                                        <Insets right="25.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font size="14.0" />
+                                     </font>
+                                  </Hyperlink>
+                                  <Label text="Copyright 2017 TheOrangeAlliance.org" GridPane.columnSpan="2147483647" GridPane.rowIndex="8">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font size="11.0" />
+                                     </font>
+                                  </Label>
+                               </children>
+                            </GridPane>
+                            <GridPane layoutX="360.0" layoutY="13.0" prefHeight="399.0" prefWidth="350.0">
+                               <columnConstraints>
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                               </columnConstraints>
+                               <rowConstraints>
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                               </rowConstraints>
+                               <children>
+                                  <Label text="Scoring System" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER">
+                                     <font>
+                                        <Font size="28.0" />
+                                     </font>
+                                  </Label>
+                                  <Label text="4. Start the FTC Scoring System and modify your event information. Once complete, choose the root folder of the scoring software." wrapText="true" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" GridPane.rowSpan="2">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" />
+                                     </GridPane.margin>
+                                     <font>
+                                        <Font name="System Bold" size="12.0" />
+                                     </font>
+                                  </Label>
+                                  <TextField fx:id="txtSetupDir" promptText="C:\Users\KyleFlynn\Scoring\FTC_Scoring" GridPane.columnSpan="3" GridPane.rowIndex="4">
+                                     <GridPane.margin>
+                                        <Insets left="10.0" right="10.0" />
+                                     </GridPane.margin>
+                                  </TextField>
+                                  <Button fx:id="btnSetupSelect" mnemonicParsing="false" onAction="#openScoringDialog" text="Open Folder" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
+                                  <Label fx:id="labelSetupDir" alignment="CENTER" prefHeight="35.0" prefWidth="150.0" text="Invalid Directory" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
+                                  <Button fx:id="btnSetupTestDir" mnemonicParsing="false" onAction="#testDirectory" text="Test Directory" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.rowIndex="6" />
+                               </children>
+                            </GridPane>
+                         </children></AnchorPane>
+                </content>
             </Tab>
             <Tab fx:id="tabTeams" closable="false" disable="true" text="Teams">
                 <content>

--- a/res/DataSync.fxml
+++ b/res/DataSync.fxml
@@ -12,8 +12,8 @@
    <children>
       <TabPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="455.0" prefWidth="720.0" tabClosingPolicy="UNAVAILABLE" AnchorPane.bottomAnchor="0.025" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
         <tabs>
-          <Tab fx:id="tabSetup" closable="false" text="Setup">
-            <content>
+            <Tab fx:id="tabSetup" closable="false" text="Setup">
+                <content>
               <AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="426.0" prefWidth="720.0">
                      <children>
                         <Separator layoutX="357.0" layoutY="13.0" orientation="VERTICAL" prefHeight="400.0" />
@@ -141,45 +141,45 @@
                         </GridPane>
                      </children></AnchorPane>
             </content>
-          </Tab>
-          <Tab fx:id="tabTeams" closable="false" disable="true" text="Teams">
-            <content>
-              <AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="451.0" prefWidth="720.0">
-                     <children>
-                        <TableView fx:id="tableTeams" prefHeight="385.0" prefWidth="720.0" AnchorPane.bottomAnchor="75.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                          <columns>
-                            <TableColumn fx:id="colTeamsTeam" prefWidth="75.0" resizable="false" text="TeamID" />
-                              <TableColumn fx:id="colTeamDiv" prefWidth="34.0" resizable="false" text="Div." />
-                            <TableColumn fx:id="colTeamsRegion" prefWidth="85.0" resizable="false" text="RegionID" />
-                              <TableColumn fx:id="colTeamsLeague" prefWidth="85.0" resizable="false" text="LeagueID" />
-                              <TableColumn fx:id="colTeamsShort" prefWidth="150.0" resizable="false" text="Team Name (Short)" />
-                              <TableColumn fx:id="colTeamsLong" prefWidth="165.0" resizable="false" text="Team Name (Long)" />
-                              <TableColumn fx:id="colTeamsLocation" minWidth="-1.0" prefWidth="125.0" resizable="false" text="Location" />
-                          </columns>
-                        </TableView>
-                        <GridPane layoutY="385.0" prefHeight="42.0" prefWidth="720.0">
-                          <columnConstraints>
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                          </columnConstraints>
-                          <rowConstraints>
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                          </rowConstraints>
-                           <children>
-                              <Button fx:id="btnTeamsGetTOA" mnemonicParsing="false" onAction="#getTeamsByURL" text="Import From TOA" GridPane.halignment="CENTER" />
-                              <Button fx:id="btnTeamsGet" mnemonicParsing="false" onAction="#getTeamsByFile" text="Import From Scoring System" GridPane.columnIndex="1" GridPane.halignment="CENTER">
-                                 <font>
-                                    <Font size="12.0" />
-                                 </font></Button>
-                              <Button fx:id="btnTeamsDelete" mnemonicParsing="false" onAction="#deleteEventTeams" text="Purge EventParticipants" GridPane.columnIndex="3" GridPane.halignment="CENTER" />
-                              <Button fx:id="btnTeamsPost" mnemonicParsing="false" onAction="#postEventTeams" text="Upload to TOA" GridPane.columnIndex="2" GridPane.halignment="CENTER" />
-                           </children>
-                        </GridPane>
-                     </children></AnchorPane>
-            </content>
-          </Tab>
+            </Tab>
+            <Tab fx:id="tabTeams" closable="false" disable="true" text="Teams">
+                <content>
+                  <AnchorPane minHeight="-Infinity" minWidth="-Infinity" prefHeight="451.0" prefWidth="720.0">
+                         <children>
+                            <TableView fx:id="tableTeams" prefHeight="385.0" prefWidth="720.0" AnchorPane.bottomAnchor="75.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+                              <columns>
+                                <TableColumn fx:id="colTeamsTeam" prefWidth="75.0" resizable="false" text="TeamID" />
+                                  <TableColumn fx:id="colTeamDiv" prefWidth="34.0" resizable="false" text="Div." />
+                                <TableColumn fx:id="colTeamsRegion" prefWidth="85.0" resizable="false" text="RegionID" />
+                                  <TableColumn fx:id="colTeamsLeague" prefWidth="85.0" resizable="false" text="LeagueID" />
+                                  <TableColumn fx:id="colTeamsShort" prefWidth="150.0" resizable="false" text="Team Name (Short)" />
+                                  <TableColumn fx:id="colTeamsLong" prefWidth="165.0" resizable="false" text="Team Name (Long)" />
+                                  <TableColumn fx:id="colTeamsLocation" minWidth="-1.0" prefWidth="125.0" resizable="false" text="Location" />
+                              </columns>
+                            </TableView>
+                            <GridPane layoutY="385.0" prefHeight="42.0" prefWidth="720.0">
+                              <columnConstraints>
+                                <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                                  <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              </columnConstraints>
+                              <rowConstraints>
+                                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              </rowConstraints>
+                               <children>
+                                  <Button fx:id="btnTeamsGetTOA" mnemonicParsing="false" onAction="#getTeamsByURL" text="Import From TOA" GridPane.halignment="CENTER" />
+                                  <Button fx:id="btnTeamsGet" mnemonicParsing="false" onAction="#getTeamsByFile" text="Import From Scoring System" GridPane.columnIndex="1" GridPane.halignment="CENTER">
+                                     <font>
+                                        <Font size="12.0" />
+                                     </font></Button>
+                                  <Button fx:id="btnTeamsDelete" mnemonicParsing="false" onAction="#deleteEventTeams" text="Purge EventParticipants" GridPane.columnIndex="3" GridPane.halignment="CENTER" />
+                                  <Button fx:id="btnTeamsPost" mnemonicParsing="false" onAction="#postEventTeams" text="Upload to TOA" GridPane.columnIndex="2" GridPane.halignment="CENTER" />
+                               </children>
+                            </GridPane>
+                         </children></AnchorPane>
+                </content>
+            </Tab>
             <Tab fx:id="tabMatches" disable="true" text="Matches">
               <content>
                 <AnchorPane minHeight="0.0" minWidth="0.0" prefHeight="180.0" prefWidth="200.0">

--- a/src/org/theorangealliance/datasync/DataSyncController.java
+++ b/src/org/theorangealliance/datasync/DataSyncController.java
@@ -32,12 +32,16 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.ResourceBundle;
+import java.util.Scanner;
 import java.util.logging.Level;
 
 /**
  * Created by Kyle Flynn on 11/28/2017.
  */
 public class DataSyncController implements Initializable {
+
+    /* File name for saving the Key/Id/Scoring System Directory */
+    private static final String SAVE_FILE_NAME = "Settings.txt";
 
     /* This is the left-side of the setup tab. */
     @FXML public Tab tabSetup;
@@ -135,6 +139,24 @@ public class DataSyncController implements Initializable {
         txtSetupDir.setEditable(false);
         btnSetupSelect.setDisable(true);
         btnSetupTestDir.setDisable(true);
+
+        //Check for default settings
+        try (Scanner scan = new Scanner(new File(SAVE_FILE_NAME))){
+
+            if(scan.hasNextLine()){
+                txtSetupKey.setText(scan.nextLine());
+            }
+            if(scan.hasNextLine()){
+                txtSetupID.setText(scan.nextLine());
+            }
+            if(scan.hasNextLine()){
+                txtSetupDir.setText(scan.nextLine());
+            }
+
+        } catch (FileNotFoundException e){
+            /* There were no saved strings, continue as is*/
+        }
+
     }
 
     @FXML
@@ -149,6 +171,7 @@ public class DataSyncController implements Initializable {
     @FXML
     public void testConnection() {
         if (txtSetupKey.getText().length() > 0 && txtSetupID.getText().length() > 0) {
+            saveSettings();
             // This will grab the base URL.
             TOAEndpoint testConnection = new TOAEndpoint("GET", "event/" + txtSetupID.getText());
             testConnection.setCredentials(txtSetupKey.getText(), txtSetupID.getText());
@@ -207,6 +230,7 @@ public class DataSyncController implements Initializable {
     @FXML
     public void testDirectory() {
         if (txtSetupDir.getText().length() > 0) {
+            saveSettings();
             String root = txtSetupDir.getText();
             File divisionsFile = new File(root + File.separator + "divisions.txt");
             if (divisionsFile.exists()) {
@@ -342,6 +366,24 @@ public class DataSyncController implements Initializable {
 
     public HashMap<Integer, int[]> getTeamWL() {
         return this.matchesController.getTeamWL();
+    }
+
+    private void saveSettings(){
+
+        try (PrintWriter out = new PrintWriter(SAVE_FILE_NAME)){
+
+            out.println(txtSetupKey.getText());
+            out.println(txtSetupID.getText());
+            out.println(txtSetupDir.getText());
+
+            out.close();
+
+        }catch (FileNotFoundException e){
+
+            TOALogger.log(Level.WARNING, "Error saving settings");
+
+        }
+
     }
 
 }

--- a/src/org/theorangealliance/datasync/DataSyncController.java
+++ b/src/org/theorangealliance/datasync/DataSyncController.java
@@ -1,7 +1,6 @@
 package org.theorangealliance.datasync;
 
 import com.sun.corba.se.impl.orbutil.concurrent.Sync;
-import com.sun.istack.internal.Nullable;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -26,7 +25,6 @@ import org.theorangealliance.datasync.util.TOAEndpoint;
 import javax.swing.*;
 import java.awt.*;
 import java.io.*;
-import java.lang.reflect.Field;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -446,7 +444,7 @@ public class DataSyncController implements Initializable {
     }
 
     /* Prompts the user to select a file from the list, or run without a file */
-    @Nullable private String promptForSaveFile(ArrayList<String> files){
+    private String promptForSaveFile(ArrayList<String> files){
 
         //New pane without text
         JOptionPane fileSelector = new JOptionPane("");

--- a/src/org/theorangealliance/datasync/DataSyncController.java
+++ b/src/org/theorangealliance/datasync/DataSyncController.java
@@ -40,7 +40,7 @@ import java.util.logging.Level;
  */
 public class DataSyncController implements Initializable {
 
-    /* File name for saving the Key/Id/Scoring System Directory */
+    /* File format for saving the Key/Id/Scoring System Directory */
     private static final String[] SAVE_FILE_FORMAT = {"Settings" , ".txt"};
     /* Default output file */
     private String saveFileName = "Settings.txt";
@@ -116,6 +116,15 @@ public class DataSyncController implements Initializable {
     @FXML public TableColumn<TeamRanking, Integer> colRankPlayed;
     @FXML public Button btnRankUpload;
 
+    /* This is for our alliances tab */
+    @FXML public Tab tabAllianceSelection;
+
+    /* This is for our awards tab */
+    @FXML public Tab tabAwards;
+
+    /* This is for our advancement tab */
+    @FXML public Tab tabAdvancement;
+
     /* This is for our sync tab. */
     @FXML public Tab tabSync;
     @FXML public Button btnSyncStart;
@@ -138,9 +147,18 @@ public class DataSyncController implements Initializable {
         labelSetupTest.setTextFill(Color.RED);
         labelSetupDir.setTextFill(Color.RED);
 
-        txtSetupDir.setEditable(false);
-        btnSetupSelect.setDisable(true);
-        btnSetupTestDir.setDisable(true);
+
+        if(!Config.BETA_TESTING){
+
+            txtSetupDir.setEditable(false);
+            btnSetupSelect.setDisable(true);
+            btnSetupTestDir.setDisable(true);
+
+        }else{
+
+            enableAllWindows();
+
+        }
 
         readSettings();
 
@@ -376,22 +394,21 @@ public class DataSyncController implements Initializable {
     private void readSettings(){
         //Check for saved settings
         try {
-
             //Looks for files of the proper format
             for(File file : new File(System.getProperty("user.dir")).listFiles()) {
                 String name = file.getName();
-                if(file.isFile() //Not a directory
-                        && name.length() >= SAVE_FILE_FORMAT[0].length()
-                        && name.substring(0,SAVE_FILE_FORMAT[0].length()).equalsIgnoreCase(SAVE_FILE_FORMAT[0])//Starts with intro string
-                        && name.substring(name.length()-SAVE_FILE_FORMAT[1].length(),name.length()).equalsIgnoreCase(SAVE_FILE_FORMAT[1])) {//Ends with proper file type
+                if (file.isFile() //Checks that the file is not a directory
+                        && name.length() >= SAVE_FILE_FORMAT[0].length() && name.length() >= SAVE_FILE_FORMAT[1].length() //Checks for really short file names
+                        && name.substring(0, SAVE_FILE_FORMAT[0].length()).equalsIgnoreCase(SAVE_FILE_FORMAT[0]) //Starts with intro string
+                        && name.substring(name.length() - SAVE_FILE_FORMAT[1].length(), name.length()).equalsIgnoreCase(SAVE_FILE_FORMAT[1])) { //Ends with proper file type
 
                     saveFileName = name;
 
                     Scanner scan = new Scanner(new File(saveFileName));
-                    while(scan.hasNextLine()){
+                    while (scan.hasNextLine()) {
                         String[] line = scan.nextLine().split(":");
 
-                        if(line.length > 1) {
+                        if (line.length > 1) {
                             if (line[0].equalsIgnoreCase("Key")) {
 
                                 txtSetupKey.setText(line[1]);
@@ -418,5 +435,18 @@ public class DataSyncController implements Initializable {
         } catch (NullPointerException e){
             /* Possible error with the system property */
         }
+    }
+
+    private void enableAllWindows(){
+
+        tabAdvancement.setDisable(false);
+        tabAllianceSelection.setDisable(false);
+        tabAwards.setDisable(false);
+        tabMatches.setDisable(false);
+        tabRankings.setDisable(false);
+        tabSetup.setDisable(false);
+        tabSync.setDisable(false);
+        tabTeams.setDisable(false);
+
     }
 }

--- a/src/org/theorangealliance/datasync/DataSyncController.java
+++ b/src/org/theorangealliance/datasync/DataSyncController.java
@@ -148,7 +148,7 @@ public class DataSyncController implements Initializable {
 
     @FXML
     public void testConnection() {
-        if (txtSetupKey.getText().length() > 0 && txtSetupKey.getText().length() > 0) {
+        if (txtSetupKey.getText().length() > 0 && txtSetupID.getText().length() > 0) {
             // This will grab the base URL.
             TOAEndpoint testConnection = new TOAEndpoint("GET", "event/" + txtSetupID.getText());
             testConnection.setCredentials(txtSetupKey.getText(), txtSetupID.getText());

--- a/src/org/theorangealliance/datasync/util/Config.java
+++ b/src/org/theorangealliance/datasync/util/Config.java
@@ -5,7 +5,7 @@ package org.theorangealliance.datasync.util;
  */
 public class Config {
 
-    public static String VERSION = "v1.3.9-BETA";
+    public static String VERSION = "v1.5.0";
 
     public static String EVENT_API_KEY;
     public static String EVENT_ID;


### PR DESCRIPTION
1. Adds support for saving matches ( #8 )
-Allows us to give tournament staff files with all the settings set up beforehand
-Prevents the tournament staff from having to retype all of the settings if the app or computer crashes
-Allows the user to select from multiple possible settings files if more than one is detected, or run without one
2. Adds support for BETA testing
-Setting the BETA_TESTING field in Config to true will now enable all windows without having to successfully connect to TOA
3. Fixes a small indentation error in the DataSync.fxml file