### PR TITLE
Adds the ability to purge matches and properly interprets Cards/DQs/No Shows

### DIFF
--- a/res/DataSync.fxml
+++ b/res/DataSync.fxml
@@ -192,16 +192,24 @@
                           </columns>
                         </TableView>
                         <GridPane layoutX="225.0" prefHeight="75.0" prefWidth="495.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
-                          <columnConstraints>
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                           <columnConstraints>
                               <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                          </columnConstraints>
-                          <rowConstraints>
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                          </rowConstraints>
+                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                           </columnConstraints>
+                           <rowConstraints>
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                           </rowConstraints>
                            <children>
+                               <Button fx:id="btnDeleteMatches"  maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#deleteMatches" text="Purge All TOA Data"  GridPane.rowIndex="0" GridPane.columnIndex="5" GridPane.columnSpan="2" GridPane.halignment="RIGHT">
+                                   <GridPane.margin>
+                                       <Insets right="10.0" />
+                                   </GridPane.margin>
+                                   <font>
+                                       <Font size="11.0" />
+                                   </font>
+                               </Button>
                               <Label text="Match Schedule Import" textAlignment="CENTER" GridPane.columnSpan="2147483647" GridPane.halignment="CENTER">
                                  <font>
                                     <Font name="System Bold" size="18.0" />
@@ -215,32 +223,32 @@
                                     <Font size="11.0" />
                                  </font>
                               </Button>
-                              <Button fx:id="btnMatchScheduleUpload" mnemonicParsing="false" onAction="#postMatchSchedule" text="Upload Schedule to TOA" GridPane.columnIndex="1" GridPane.columnSpan="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
-                                 <GridPane.margin>
-                                    <Insets right="10.0" />
-                                 </GridPane.margin>
-                              </Button>
+                              <Button fx:id="btnMatchScheduleUpload" mnemonicParsing="false" onAction="#postMatchSchedule" text="Upload Schedule to TOA" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
+                                   <GridPane.margin>
+                                       <Insets right="10.0" />
+                                   </GridPane.margin>
+                               </Button>
                               <Label fx:id="labelScheduleUploaded" text="Label" textAlignment="CENTER" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="1" />
                            </children>
                         </GridPane>
                         <Separator layoutX="225.0" layoutY="74.0" prefHeight="2.0" prefWidth="500.0" AnchorPane.rightAnchor="0.0" />
                         <GridPane layoutX="225.0" layoutY="74.0" prefHeight="344.0" prefWidth="500.0" AnchorPane.rightAnchor="0.0">
                           <columnConstraints>
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                               <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                               <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                               <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                               <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
-                            <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
+                              <ColumnConstraints hgrow="SOMETIMES" minWidth="10.0" prefWidth="100.0" />
                           </columnConstraints>
                           <rowConstraints>
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                               <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
-                            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                              <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
                           </rowConstraints>
                            <children>
                               <Label text="Match Detail View" GridPane.columnIndex="2" GridPane.columnSpan="2" GridPane.halignment="CENTER" GridPane.valignment="TOP">
@@ -314,7 +322,9 @@
                               <Button fx:id="btnMatchOpen" maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" onAction="#openMatchDetails" prefWidth="85.0" text="View Details" GridPane.columnIndex="4" GridPane.halignment="LEFT" GridPane.rowIndex="6" />
                            </children>
                         </GridPane>
-                     </children></AnchorPane>
+                        <Separator layoutX="225.0" layoutY="360.0" prefHeight="2.0" prefWidth="500.0" AnchorPane.rightAnchor="0.0" />
+                     </children>
+                </AnchorPane>
               </content>
             </Tab>
             <Tab fx:id="tabRankings" disable="true" text="Rankings">
@@ -349,7 +359,8 @@
                               <Button mnemonicParsing="false" onAction="#getRankingsByFile" text="Import From Scoring System" GridPane.halignment="CENTER" />
                            </children>
                         </GridPane>
-                     </children></AnchorPane>
+                     </children>
+                </AnchorPane>
               </content>
             </Tab>
             <Tab fx:id="tabAllianceSelection" disable="true" text="Alliance Selection">
@@ -424,6 +435,7 @@
       <Label fx:id="txtConsole" layoutY="461.0" prefHeight="20.0" prefWidth="720.0">
          <padding>
             <Insets left="10.0" />
-         </padding></Label>
+         </padding>
+      </Label>
    </children>
 </AnchorPane>

--- a/src/org/theorangealliance/datasync/DataSyncController.java
+++ b/src/org/theorangealliance/datasync/DataSyncController.java
@@ -1,6 +1,5 @@
 package org.theorangealliance.datasync;
 
-import com.sun.corba.se.impl.orbutil.concurrent.Sync;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -29,7 +28,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 import java.util.*;
 import java.util.logging.Level;
 
@@ -326,6 +324,11 @@ public class DataSyncController implements Initializable {
     }
 
     @FXML
+    public void deleteMatches(){
+        this.matchesController.deleteMatches();
+    }
+
+    @FXML
     public void startAutoSync() {
         DataSync.getMainStage().setOnCloseRequest(closeEvent -> this.syncController.kill());
         this.syncController.execute((count) -> {
@@ -457,10 +460,18 @@ public class DataSyncController implements Initializable {
 
         //Makes and shows the window
         JDialog window = fileSelector.createDialog(null, "Select a Settings File");
+        window.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         window.setVisible(true);
 
         //returns the selected value if "Select File" was pressed, null otherwise
-        return fileSelector.getValue().equals("Select File") ? (String)fileSelector.getInputValue() : null;
+        try {
+            return fileSelector.getValue().equals("Select File") ? (String) fileSelector.getInputValue() : null;
+        }catch (NullPointerException e){//When the user closes the window
+            System.exit(0);
+        }
+
+        //We don't go here
+        return null;
 
     }
 

--- a/src/org/theorangealliance/datasync/models/ScheduleStation.java
+++ b/src/org/theorangealliance/datasync/models/ScheduleStation.java
@@ -8,6 +8,7 @@ public class ScheduleStation {
     private String stationKey;
     private String matchKey;
     private int station;
+    //-2:Disqualified -1:No Show 0:Surrogate 1:Nothing 2: Yellow Card
     private int stationStatus;
     private int teamKey;
 
@@ -42,6 +43,25 @@ public class ScheduleStation {
                 break;
         }
         return suffix;
+    }
+
+    public String getStatusString(){
+
+        switch(stationStatus){
+
+            case -2:
+                return "(Disqualified)";
+            case -1:
+                return "(No Show)";
+            case 0:
+                return "*";
+            case 2:
+                return "(Yellow Card)";
+            default:
+                return "";
+
+        }
+
     }
 
     public String getStationKey() {

--- a/src/org/theorangealliance/datasync/tabs/SyncController.java
+++ b/src/org/theorangealliance/datasync/tabs/SyncController.java
@@ -54,7 +54,7 @@ public class SyncController implements Runnable {
             this.totalSyncs = 0;
             controller.btnSyncStop.setDisable(false);
             controller.btnSyncMatches.setDisable(true);
-            service.scheduleAtFixedRate(this, 0, 5, TimeUnit.SECONDS);
+            service.scheduleAtFixedRate(this, 0, 30, TimeUnit.SECONDS);
             executeAdapter = toaExecuteAdapter;
         }
     }

--- a/src/org/theorangealliance/datasync/util/Config.java
+++ b/src/org/theorangealliance/datasync/util/Config.java
@@ -5,7 +5,7 @@ package org.theorangealliance.datasync.util;
  */
 public class Config {
 
-    public static String VERSION = "v1.5.0";
+    public static String VERSION = "v1.5.1";
 
     public static String EVENT_API_KEY;
     public static String EVENT_ID;


### PR DESCRIPTION
1. Adds the ability to purge matches: #1 
    -Adds a button to the matches page to purge all data from the TOA server
    -This removes all match data, details, schedule, and team station information
2. Adds the ability to interpret Cards/DQs/No Shows: #5 
    -This allows the datasync program to detect more of these station statuses
    -This also appears to have fixed #2, as it seems that the discrepancies in rankings seems to have stemmed from the lack of detection of these settings
3. Other: #3 and #4 
    -It seems that at some point in the patching process, @kyle-flynn  managed to fix both of these issues, and after testing the other new features, I think that these can also be struck from the issues list