### PR TITLE
Add new Innovate Award Name

### DIFF
--- a/src/org/theorangealliance/datasync/tabs/AwardsController.java
+++ b/src/org/theorangealliance/datasync/tabs/AwardsController.java
@@ -311,6 +311,8 @@ public class AwardsController {
                 return "CNT";
             case "Rockwell Collins Innovate Award":
                 return "INV";
+            case "Collins Aerospace Innovate Award":
+                return "INV";
             case "Design Award":
                 return "DSN";
             case "Motivate Award":


### PR DESCRIPTION
The Rockwell Collins Innovate Award changed names to Collins Aerospace Innovate Award.  This change maintains backwards compatibility to older versions of the scorekeeper software while updating to the new version as well.

This fixes #18